### PR TITLE
Make the log of token IDs minted simple

### DIFF
--- a/script/finpl/mint_batch.ts
+++ b/script/finpl/mint_batch.ts
@@ -42,7 +42,9 @@ async function main() {
     console.log("====== Combine tokenIds(HEX) ======")
     console.log(tokenIdsStr.slice(0, -3));
     console.log("====== Combine tokenIds ======");
-    console.log(tokenIds);
+    for (let id of tokenIds) {
+        console.log(id.toString());
+    }
 
     await proxyContract.batchMint(creator, tokenIds, quantities, buffer);
     console.log("All tokens minted to:", creator);


### PR DESCRIPTION
`batchMint`시에 로그에서 다음과 같이 Combined Token ID가 단순하게 표시되도록 수정함.

```
====== Combine tokenIds ======
49215977377223998536466210884262356201340682100119970677713417968093212180580
49215977377223998536466210884262356201340682100119970677713417969192723808356
49215977377223998536466210884262356201340682100119970677713417970292235436132
49215977377223998536466210884262356201340682100119970677713417971391747063908
49215977377223998536466210884262356201340682100119970677713417972491258691684
49215977377223998536466210884262356201340682100119970677713417973590770319460
49215977377223998536466210884262356201340682100119970677713417974690281947236
49215977377223998536466210884262356201340682100119970677713417975789793575012
49215977377223998536466210884262356201340682100119970677713417976889305202788
49215977377223998536466210884262356201340682100119970677713417977988816830564
All tokens minted to: 0x6cCf418bff364e8d55628060EF274B155892B61C
```