### PR TITLE
Change type of `token index` to BigNumber

### DIFF
--- a/script/check_nft.ts
+++ b/script/check_nft.ts
@@ -19,14 +19,14 @@ async function main() {
     const ownerAssetContract = await assetContract.connect(adminSigner);
 
     const tokenId = BigNumber.from(process.env.FINPL_NFT_LAST_COMBINE_TOKEN_ID || "");
-    const [address, tokenIndex, maxSupply] = parseTokenId(tokenId);
+    const [address, tokenIndex, maxSupply] = parseTokenId(tokenId.toString());
 
     console.log("====== Minted NFT information ======");
     console.log("tokenId:", tokenId);
     console.log("tokenId(HEX):", tokenId.toHexString());
     console.log("uri:", await ownerAssetContract.uri(tokenId));
     console.log("creator:", await ownerAssetContract.creator(tokenId));
-    console.log("token index:", tokenIndex);
+    console.log("token index:", tokenIndex.toString());
     console.log("max supply:", maxSupply);
     console.log("balance of creator:",
         (await ownerAssetContract.balanceOf(creator, tokenId)).toString());

--- a/script/finpl/mint_batch_metadata.ts
+++ b/script/finpl/mint_batch_metadata.ts
@@ -20,7 +20,7 @@ async function main() {
     const creatorContract = await assetContract.connect(creatorSigner);
 
     const batchCount = Number(process.env.FINPL_NFT_BATCH_COUNT || "1");
-    const tokenIndex = Number(process.env.FINPL_NFT_INDEX || "0");
+    const tokenIndex = BigNumber.from(process.env.FINPL_NFT_INDEX || "0");
     const data = process.env.FINPL_NFT_DATA || "";
     const buffer = ethers.utils.toUtf8Bytes(data);
 
@@ -32,7 +32,7 @@ async function main() {
     for (let i = 0; i < batchCount; i++) {
         const quantity = Number(process.env.FINPL_NFT_QUANTITY || "1");
         quantities.push(quantity);
-        const tokenId = createTokenId(creator.address, tokenIndex + 1 + i, quantity);
+        const tokenId = createTokenId(creator.address, tokenIndex.add(i), quantity);
         tokenIdsStr += tokenId.toHexString() + " , ";
         tokenIds.push(tokenId);
     }

--- a/script/finpl/mint_metadata.ts
+++ b/script/finpl/mint_metadata.ts
@@ -20,11 +20,11 @@ async function main() {
     const creatorContract = await assetContract.connect(creatorSigner);
 
     const quantity = Number(process.env.FINPL_NFT_QUANTITY || "1");
-    const tokenIndex = Number(process.env.FINPL_NFT_INDEX || "0");
+    const tokenIndex = BigNumber.from(process.env.FINPL_NFT_INDEX || "0");
     const data = process.env.FINPL_NFT_DATA || "";
     const buffer = ethers.utils.toUtf8Bytes(data);
 
-    const tokenId = createTokenId(creator.address, tokenIndex + 1, quantity);
+    const tokenId = createTokenId(creator.address, tokenIndex, quantity);
     console.log("Combined tokenId:", tokenId.toString(), "(", tokenId.toHexString(), ")");
 
     await creatorContract.mint(creator.address, tokenId, quantity, buffer);

--- a/utils/ParseTokenID.ts
+++ b/utils/ParseTokenID.ts
@@ -1,7 +1,7 @@
 import { BigNumber} from "ethers";
 import { utils } from "ethers";
 
-export function parseTokenId(tokenId: string): [string, number, number] {
+export function parseTokenId(tokenId: string): [string, BigNumber, number] {
     const ADDRESS_BITS = 160;
     const INDEX_BITS = 56;
     const SUPPLY_BITS = 40;
@@ -11,19 +11,18 @@ export function parseTokenId(tokenId: string): [string, number, number] {
     const INDEX_MASK = BigNumber.from(1).shl(INDEX_BITS).sub(1).xor(SUPPLY_MASK);
 
     const address = lastNftId.shr(INDEX_BITS + SUPPLY_BITS).toHexString();
-    const tokenIndex = lastNftId.and(INDEX_MASK).shr(SUPPLY_BITS).toNumber();
+    const tokenIndex = lastNftId.and(INDEX_MASK).shr(SUPPLY_BITS);
     const maxSupply = lastNftId.and(SUPPLY_MASK).toNumber();
 
     return [address, tokenIndex, maxSupply];
 }
 
-export function createTokenId(address: string, index: number, maxSupply: number)
+export function createTokenId(address: string, index: BigNumber, maxSupply: number)
 : BigNumber {
     let makerPart = BigNumber.from(utils.hexZeroPad(address, 32));
     makerPart = makerPart.shl(96); // shift 12 bytees
-    let newIdPart = BigNumber.from(index);
-    newIdPart = newIdPart.shl(40); // shift 5 bytes
-    let quantityPart = BigNumber.from(maxSupply);
+    const newIdPart = index.shl(40);
+    const quantityPart = BigNumber.from(maxSupply);
     const tokenId = makerPart.add(newIdPart).add(quantityPart);
 
     return tokenId;


### PR DESCRIPTION
Typescript `number` type has the 52-bit size of significand in double-precision 64-bit number but the `token index` of BoaSpace NFT token ID (aka Combined Token ID) has 56 bits and `maxSupply` has 40 bits. So the `token index` exceeds the bit size of the index which is not a real case but we should have it checked.

This pr changes the type of `token index` to `BigNumber`.