### PR TITLE
Set proxy for SharedStorefrontLazyMintAdapter

### DIFF
--- a/script/fulfill/storefront_basic_order_erc1155.ts
+++ b/script/fulfill/storefront_basic_order_erc1155.ts
@@ -31,8 +31,7 @@ async function main() {
     setContracts(marketplace, assetToken);
 
     // set the shared proxy of assetToken to SharedStorefront
-    await assetToken.connect(adminSigner).setApprovalForAll(marketplace.address, true);
-    // await assetToken.connect(adminSigner).addSharedProxyAddress(marketplace.address);
+    await assetToken.connect(adminSigner).addSharedProxyAddress(storefront.address);
 
     // TODO: Make utility functions creating offer and consideration
 

--- a/script/fulfill/storefront_basic_order_wboa.ts
+++ b/script/fulfill/storefront_basic_order_wboa.ts
@@ -37,8 +37,7 @@ async function main() {
     setContracts(marketplace, assetToken);
 
     // set the shared proxy of assetToken to SharedStorefront
-    await assetToken.connect(adminSigner).setApprovalForAll(marketplace.address, true);
-    // await assetToken.connect(adminSigner).addSharedProxyAddress(marketplace.address);
+    await assetToken.connect(adminSigner).addSharedProxyAddress(storefront.address);
 
     // The needed amount of WBOA for trading
     const sellerAmount = ethers.utils.parseEther("0.1");


### PR DESCRIPTION
We set the shared proxy of the AssetContractShared to the marketplace. But we should set it to the SharedStorefrontLazyMintAdapter as the caller of `safeTransferFrom` is the lazy mining contract now.
