### PR TITLE
Set the Seaport and Conduit addresses on the SharedStorefrontLazyMintAdapter

### DIFF
--- a/contracts/lazymint/SharedStorefrontLazyMintAdapter.sol
+++ b/contracts/lazymint/SharedStorefrontLazyMintAdapter.sol
@@ -20,10 +20,8 @@ import { IERC1155 } from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
  */
 contract SharedStorefrontLazyMintAdapter {
     IERC1155 immutable ssfToken;
-    address private constant SEAPORT =
-    0x4F445109d11419c3612e43D2e71a3593921621E0;
-    address private constant CONDUIT =
-    0x65a14fDc9d62fc15454FE3ba1b59ABc59FF58A1b;
+    address immutable SEAPORT;
+    address immutable CONDUIT;
 
     error InsufficientBalance();
     error UnauthorizedCaller();
@@ -53,7 +51,9 @@ contract SharedStorefrontLazyMintAdapter {
         _;
     }
 
-    constructor(address tokenAddress) {
+    constructor(address seaportAddress, address conduitAddress, address tokenAddress) {
+        SEAPORT = seaportAddress;
+        CONDUIT = conduitAddress;
         ssfToken = IERC1155(tokenAddress);
     }
 
@@ -95,7 +95,7 @@ contract SharedStorefrontLazyMintAdapter {
      */
     function isApprovedForAll(address, address operator)
     public
-    pure
+    view
     returns (bool)
     {
         return operator == CONDUIT || operator == SEAPORT;

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "build": "hardhat compile --config ./hardhat.config.ts",
     "build:ref": "hardhat compile --config ./hardhat-reference.config.ts",
     "test": "hardhat test --config ./hardhat.config.ts",
+    "test:boa": "hardhat test --config ./hardhat.config.ts test/boaspace/*.ts",
     "test:ref": "REFERENCE=true hardhat test --config ./hardhat-reference.config.ts",
     "profile": "REPORT_GAS=true hardhat test --config ./hardhat.config.ts",
     "coverage": "hardhat coverage --config ./hardhat-coverage.config.ts --solcoverjs ./config/.solcover.js",
@@ -88,7 +89,7 @@
     "test:forge:lite": "FOUNDRY_PROFILE=reference forge build; FOUNDRY_PROFILE=lite forge test -vvv",
     "prepare": "husky install",
     "prettier:ts": "node_modules/.bin/prettier --write --config .prettierrc 'test/**/*.ts' 'utils/**/*.ts' 'script/**/*.ts'",
-    "prettier:ts:boa": "node_modules/.bin/prettier --write --config .prettierrc 'script/**/*.ts' 'utils/*.ts' 'test/boaspace.basicfulfill.ts'"
+    "prettier:ts:boa": "node_modules/.bin/prettier --write --config .prettierrc 'script/**/*.ts' 'utils/*.ts' 'test/boaspace/*.ts'"
   },
   "lint-staged": {
     "*.sol": "prettier --write",

--- a/script/README.md
+++ b/script/README.md
@@ -122,14 +122,6 @@ templateURI:
 ```
 
 ### Deploying SharedStorefrontLazyMintAdapter contract
-Before this contract, we should set the following hardcoded state variables in the `SharedStorefrontLazyMintAdapter.sol`.
-```solidity
-address private constant SEAPORT = 0x4F445109d11419c3612e43D2e71a3593921621E0;
-address private constant CONDUIT = 0xCef34f700b0F060fAA00E91001259E80Fcdc9570;
-```
-- SEAPORT: the address of the `Seaport` contract
-- CONDUIT: the address of the `Conduit` contract which is created from [this section](#creating-conduit).
-
 Run this script for deploying the contract.
 ```
 npx hardhat run script/deploy_lazymint_adapter.ts --network testnet

--- a/script/deploy_lazymint_adapter.ts
+++ b/script/deploy_lazymint_adapter.ts
@@ -5,15 +5,27 @@ import { GasPriceManager } from "../utils/GasPriceManager";
 
 async function main() {
     const LazymintAdapterFactory = await ethers.getContractFactory("SharedStorefrontLazyMintAdapter");
+    const ConduitControllerFactory = await ethers.getContractFactory("ConduitController");
     const provider = ethers.provider;
 
     const admin = new Wallet(process.env.ADMIN_KEY || "");
     const adminSigner = new NonceManager(new GasPriceManager(provider.getSigner(admin.address)));
 
-    const tokenAddress = process.env.ASSET_CONTRACT_SHARED_ADDRESS || "";
-    const lazymintAdapter = await LazymintAdapterFactory.connect(adminSigner).deploy(tokenAddress);
-    await lazymintAdapter.deployed();
+    const marketplaceAddress = process.env.SEAPORT_ADDRESS;
 
+    const conduitContorller = await ConduitControllerFactory.attach(process.env.CONDUIT_CONTROLLER_ADDRESS || "");
+    const ownerConduitContorller = await conduitContorller.connect(adminSigner);
+    const conduitKey = process.env.CONDUIT_KEY || "";
+    const { conduit: conduitAddress, exists } = await ownerConduitContorller.getConduit(conduitKey);
+    console.log("seaportAddress: %s, conduitAddress: %s", marketplaceAddress, conduitAddress);
+
+    const tokenAddress = process.env.ASSET_CONTRACT_SHARED_ADDRESS || "";
+    const lazymintAdapter = await LazymintAdapterFactory.connect(adminSigner).deploy(
+        marketplaceAddress,
+        conduitAddress,
+        tokenAddress
+    );
+    await lazymintAdapter.deployed();
     console.log("SharedStorefrontLazyMintAdapter - deployed to:", lazymintAdapter.address);
 }
 

--- a/script/fulfill/order_asset_erc1155_to_boa.ts
+++ b/script/fulfill/order_asset_erc1155_to_boa.ts
@@ -23,6 +23,7 @@ async function main() {
     const admin = new Wallet(process.env.ADMIN_KEY || "");
     const zone = new Wallet(process.env.ZONE_KEY || "");
     const nftSeller = new Wallet(process.env.ORDER_NFT_SELLER_KEY || "");
+    const nftSellerSigner = new NonceManager(new GasPriceManager(provider.getSigner(nftSeller.address)));
     const adminSigner = new NonceManager(new GasPriceManager(provider.getSigner(admin.address)));
     const marketplaceContract = await SeaportFactory.attach(process.env.SEAPORT_ADDRESS || "");
     const sharedAsset = await AssetContractFactory.attach(process.env.ASSET_CONTRACT_SHARED_ADDRESS || "");
@@ -30,8 +31,9 @@ async function main() {
     setContracts(marketplaceContract, sharedAsset);
 
     // approve to the marketplace
-    await sharedAsset.connect(adminSigner).setApprovalForAll(marketplaceContract.address, true);
     // await sharedAsset.connect(adminSigner).addSharedProxyAddress(marketplaceContract.address);
+
+    await sharedAsset.connect(nftSellerSigner).setApprovalForAll(marketplaceContract.address, true);
     console.log("SetApprovalForAll called");
 
     // NFT seller creates an order that has an NFT token that he owns

--- a/test/boaspace/basicfulfill.ts
+++ b/test/boaspace/basicfulfill.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { ethers, network, waffle } from "hardhat";
-import { faucet } from "./utils/faucet";
+import { faucet } from "../utils/faucet";
 import type {
     AssetContractShared,
     AssetContractShared__factory as AssetContractSharedFactory,
@@ -11,12 +11,12 @@ import type {
     Seaport__factory as SeaportFactory,
     SharedStorefrontLazyMintAdapter,
     SharedStorefrontLazyMintAdapter__factory as SharedStorefrontLazyMintAdapterFactory,
-} from "../typechain-types";
-import { createOrder, setChainId, setSeaport } from "../utils/CommonFunctions";
-import { createTokenId } from "../utils/ParseTokenID";
+} from "../../typechain-types";
+import { createOrder, setChainId, setSeaport } from "../../utils/CommonFunctions";
+import { createTokenId } from "../../utils/ParseTokenID";
 import { BigNumber, BigNumberish } from "ethers";
-import { getItemETH, toBN, toKey } from "./utils/encoding";
-import type { OfferItem } from "./utils/types";
+import { getItemETH, toBN, toKey } from "../utils/encoding";
+import type { OfferItem } from "../utils/types";
 const { parseEther } = ethers.utils;
 
 const ZeroAddress = "0x0000000000000000000000000000000000000000";
@@ -89,18 +89,10 @@ describe(`Fulfilling a basic order offering NFT and getting BOA(BOASPACE)`, func
         await marketplace.deployed();
         console.log("Marketplace:", marketplace.address);
 
-        // Deploy SharedStorefrontLazyMintAdapter
-        const lazymintAdapterFactory = await ethers.getContractFactory("SharedStorefrontLazyMintAdapter");
-        lazymintAdapter = await lazymintAdapterFactory.connect(admin).deploy(assetToken.address);
-        await lazymintAdapter.deployed();
-        console.log("SharedStorefrontLazyMintAdapter:", lazymintAdapter.address);
-
         setSeaport(marketplace);
 
         // approve to the marketpalce
-        await assetToken.connect(adminSigner).setApprovalForAll(marketplace.address, true);
-        await assetToken.connect(adminSigner).addSharedProxyAddress(marketplace.address);
-        console.log("SetApprovalForAll called");
+        // await assetToken.connect(adminSigner).addSharedProxyAddress(marketplace.address);
     });
 
     it("Mint a AssetContractShared token", async () => {
@@ -114,6 +106,8 @@ describe(`Fulfilling a basic order offering NFT and getting BOA(BOASPACE)`, func
         console.log("Combined tokenId: %s (%s)", tokenId.toString(), tokenId.toHexString());
         await creatorContract.mint(offerer.address, tokenId, tokenQuantity, buffer);
         console.log("Token minted to:", offerer.address);
+
+        await creatorContract.setApprovalForAll(marketplace.address, true);
     });
 
     it("Transfer a AssetContractShared token", async () => {


### PR DESCRIPTION
The addresses of `Seaport` and `Conduit` are not constant values. So we should set the addresses on the `SharedStorefrontLazyMintAdapter` contracts. This change is for writing the code running on the `boa-space-seaport-js` SDK.